### PR TITLE
update log4net 2.0.8 to log4net 2.0.10

### DIFF
--- a/Easy.Logger.Extensions.Microsoft/Easy.Logger.Extensions.Microsoft.csproj
+++ b/Easy.Logger.Extensions.Microsoft/Easy.Logger.Extensions.Microsoft.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Easy.Logger" Version="3.7.3" />
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
   </ItemGroup>
 

--- a/Easy.Logger.Extensions/Easy.Logger.Extensions.csproj
+++ b/Easy.Logger.Extensions/Easy.Logger.Extensions.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.10" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">

--- a/Easy.Logger.Interfaces/Easy.Logger.Interfaces.csproj
+++ b/Easy.Logger.Interfaces/Easy.Logger.Interfaces.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net40</TargetFrameworks>
     <AssemblyTitle>Easy Logger Interfaces</AssemblyTitle>
     <AssemblyName>Easy.Logger.Interfaces</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Easy.Logger.Tests.Unit/Easy.Logger.Tests.Unit.csproj
+++ b/Easy.Logger.Tests.Unit/Easy.Logger.Tests.Unit.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />

--- a/Easy.Logger/Easy.Logger.csproj
+++ b/Easy.Logger/Easy.Logger.csproj
@@ -15,14 +15,14 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net40</TargetFrameworks>
     <AssemblyTitle>Easy Logger</AssemblyTitle>
     <AssemblyName>Easy.Logger</AssemblyName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="log4net" Version="2.0.10" />
     <PackageReference Include="Easy.Logger.Interfaces" Version="1.3.0" />
   </ItemGroup>
   


### PR DESCRIPTION
On a linux project I need to use log4net 2.0.9 or higher.
However Easy.Logger needs still log4net 2.0.8